### PR TITLE
fix: Make @vercel/nft include the Query Engine in the serverless function

### DIFF
--- a/pages/api/index.js
+++ b/pages/api/index.js
@@ -26,9 +26,11 @@ enum Role {
 }
 `;
 
-path.join('../../node_modules/@prisma/engines/query-engine-rhel-openssl-1.0.x')
-
 export default async function (req, res) {
+
+  const path = require('path');
+  path.join('../../node_modules/@prisma/engines/query-engine-rhel-openssl-1.0.x')
+
   try {
     const dmmf = await getDMMF({ datamodel });
     res.json(dmmf.datamodel);

--- a/pages/api/index.js
+++ b/pages/api/index.js
@@ -1,5 +1,10 @@
 import { getDMMF } from "@prisma/sdk";
 
+const path = require('path');
+path.join(process.cwd(), 'node_modules/@prisma/engines/query-engine-rhel-openssl-1.0.x')
+path.join(process.cwd(), 'node_modules/@prisma/engines/query-engine-windows.exe')
+
+
 const datamodel = `
 model User {
   id Int @id @default(autoincrement())
@@ -28,8 +33,6 @@ enum Role {
 
 export default async function (req, res) {
 
-  const path = require('path');
-  path.join('../../node_modules/@prisma/engines/query-engine-rhel-openssl-1.0.x')
 
   try {
     const dmmf = await getDMMF({ datamodel });

--- a/pages/api/index.js
+++ b/pages/api/index.js
@@ -26,6 +26,8 @@ enum Role {
 }
 `;
 
+path.join('../../node_modules/@prisma/engines/query-engine-rhel-openssl-1.0.x')
+
 export default async function (req, res) {
   try {
     const dmmf = await getDMMF({ datamodel });


### PR DESCRIPTION
This adds an "annotation" to "access" the query engine file (Windows for my local testing, `rhel` for AWS Lambda environment of Vercel Serverless functions) in the code, so that `@vercel/nft`, which is used under the hood by Vercel when building the serverless function, decides to include that file so it is available later when the code is executed.

And it works: https://prisma-sdk-vercel-repro-1bigpnym9-janpio.vercel.app/api